### PR TITLE
Add sentiment scraping and remove Dead Cap

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>wmonighe's Best Ball Eliminator Rankings</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>wmonighe's Best Ball Eliminator Rankings</h1>
+    </header>
+    <main>
+        <table id="rankings-table">
+            <thead></thead>
+            <tbody></tbody>
+        </table>
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.1/papaparse.min.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,128 @@
+// Rankings are loaded from the public Google Sheet using the gviz CSV export.
+// The sheet must be published to the web for this to succeed.
+const csvUrl =
+  'https://docs.google.com/spreadsheets/d/1rNouBdE-HbWafu-shO_5JLPSrLhr-xuGpXYfyOI-2oY/gviz/tq?tqx=out:csv&gid=148406078';
+
+/**
+ * Fetch rankings from the Google Sheet.
+ * @returns {Promise<Array<Object>>}
+ */
+async function fetchRankings() {
+  const response = await fetch(csvUrl);
+  const csvText = await response.text();
+  const results = Papa.parse(csvText, {
+    header: true,
+    skipEmptyLines: true,
+  });
+  return results.data;
+}
+
+/**
+ * Fetch sentiment data from taeks.com. Falls back to an empty map on error.
+ * @returns {Promise<Map<string, string>>}
+ */
+async function fetchSentiment() {
+  try {
+    const resp = await fetch('https://taeks.com/nfl/bestball/leaderboard/rookie');
+    const html = await resp.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    const table = doc.querySelector('table');
+    const map = new Map();
+    if (table) {
+      const rows = table.querySelectorAll('tr');
+      if (rows.length > 0) {
+        const headers = Array.from(rows[0].querySelectorAll('th'));
+        const playerIdx = headers.findIndex((th) =>
+          th.textContent.trim().toLowerCase().includes('player')
+        );
+        const sentimentIdx = headers.findIndex((th) =>
+          th.textContent.trim().toLowerCase().includes('sentiment')
+        );
+        for (let i = 1; i < rows.length; i++) {
+          const cells = rows[i].querySelectorAll('td');
+          if (
+            playerIdx >= 0 &&
+            sentimentIdx >= 0 &&
+            cells[playerIdx] &&
+            cells[sentimentIdx]
+          ) {
+            const name = cells[playerIdx].textContent.trim().toUpperCase();
+            const sentiment = cells[sentimentIdx].textContent.trim();
+            map.set(name, sentiment);
+          }
+        }
+      }
+    }
+    return map;
+  } catch (err) {
+    console.error('Unable to fetch sentiment data', err);
+    return new Map();
+  }
+}
+
+/**
+ * Load rankings and sentiment information, then populate the table.
+ */
+async function loadData() {
+  try {
+    const [rows, sentimentMap] = await Promise.all([
+      fetchRankings(),
+      fetchSentiment(),
+    ]);
+    populateTable(rows, sentimentMap);
+  } catch (err) {
+    const table = document.getElementById('rankings-table');
+    table.innerHTML = '<caption>Unable to load rankings.</caption>';
+    console.error(err);
+  }
+}
+
+function populateTable(rows, sentimentMap) {
+  const table = document.getElementById('rankings-table');
+  if (rows.length === 0) return;
+
+  const allHeaders = Object.keys(rows[0]);
+  const filteredHeaders = [];
+  const nameKey = allHeaders.find((h) => /player|name/i.test(h));
+
+  allHeaders.forEach((h) => {
+    if (!h || h.trim() === '') return; // skip blank
+    if (/dead\s*cap/i.test(h)) return; // remove Dead Cap column
+    if (/sentiment/i.test(h)) return; // remove any Sentiment column from sheet
+    if (!filteredHeaders.includes(h)) filteredHeaders.push(h);
+  });
+
+  filteredHeaders.push('Sentiment');
+
+  // Build table header
+  const thead = table.querySelector('thead');
+  thead.innerHTML = '';
+  const headerRow = document.createElement('tr');
+  filteredHeaders.forEach((key) => {
+    const th = document.createElement('th');
+    th.textContent = key;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+
+  // Build rows
+  const tbody = table.querySelector('tbody');
+  tbody.innerHTML = '';
+  rows.forEach((row) => {
+    const tr = document.createElement('tr');
+    filteredHeaders.forEach((key) => {
+      const td = document.createElement('td');
+      if (key === 'Sentiment') {
+        const name = nameKey ? row[nameKey].toUpperCase() : '';
+        td.textContent = name ? sentimentMap.get(name) || '' : '';
+      } else {
+        td.textContent = String(row[key] || '').replace(/,/g, '');
+      }
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+}
+
+loadData();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,44 @@
+body {
+    font-family: Arial, sans-serif;
+    background: #f9f9f9;
+    color: #333;
+    margin: 0;
+    padding: 0;
+}
+
+header {
+    background: #2a9d8f;
+    color: #fff;
+    padding: 1rem;
+    text-align: center;
+}
+
+h1 {
+    margin: 0;
+}
+
+main {
+    margin: 2rem auto;
+    width: 90%;
+    max-width: 800px;
+}
+
+#rankings-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+#rankings-table th,
+#rankings-table td {
+    border: 1px solid #ddd;
+    padding: 0.5rem;
+    text-align: left;
+}
+
+#rankings-table thead {
+    background: #e9c46a;
+}
+
+#rankings-table tbody tr:nth-child(odd) {
+    background: #f0f0f0;
+}


### PR DESCRIPTION
## Summary
- load rankings via gviz endpoint
- scrape sentiment data from taeks.com and append to table
- omit Dead Cap column and sanitize commas

## Testing
- `npm test` *(fails: package.json missing)*